### PR TITLE
Continuation of work on Get module

### DIFF
--- a/Sources/snatch/Core/Snatch.swift
+++ b/Sources/snatch/Core/Snatch.swift
@@ -28,6 +28,21 @@ public class Snatch {
     /**
         Starts a data task on a shared URLSession, resolves upon completion.
 
+        - parameter url: URL. Default headers, empty body, if you really want, put url encoded query there yourself.
+
+        - returns: Promise that fulfills with Snatch.Result object.
+    */
+    func request(_ url: URL) -> Promise<Result> {
+        return Promise { fulfill, reject in
+            let handler = self.commonHandler(fulfill, reject)
+
+            self.task(with: url, handler).resume()
+        }
+    }
+
+    /**
+        Starts a data task on a shared URLSession, resolves upon completion.
+
         - parameter request: URLRequest. Use this object to configure methods, headers and all the things.
 
         - returns: Promise that fulfills with Snatch.Result object.

--- a/Sources/snatch/Core/Snatch.swift
+++ b/Sources/snatch/Core/Snatch.swift
@@ -19,8 +19,8 @@ public class Snatch {
     */
     typealias DataTaskCallback = (Data?, URLResponse?, Error?) -> Void
 
-    init(with session: URLSession = URLSession.shared) {
-        self.session = session
+    init(with sessionConfig: URLSessionConfiguration = URLSessionConfiguration.default) {
+        self.session = URLSession(configuration: sessionConfig)
         // Give a reference to a Snatch instance to all the extensions.
         get.father = self
     }

--- a/Sources/snatch/Encoding/URLQueryEncoding.swift
+++ b/Sources/snatch/Encoding/URLQueryEncoding.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+class URLQueryEncoding {
+
+    /**
+        Expects all members to be escaped
+    */
+    func encode(_ dict: [AnyHashable: Any]) -> String {
+        return dict.map { "\($0)=\($1)" }.joined(separator: "&")
+    }
+}

--- a/Sources/snatch/Encoding/URLQueryEncoding.swift
+++ b/Sources/snatch/Encoding/URLQueryEncoding.swift
@@ -3,9 +3,36 @@ import Foundation
 class URLQueryEncoding {
 
     /**
-        Expects all members to be escaped
+        Encodes a dictionary of parameters into a URLEncoded query. Expects all members to be escaped.
+
+        - parameter dict: dictionary of parameters. Both keys and values of the dictionary must be representable as strings, otherwise - undefined behavior.
+
+        - returns: string, a URLEncoded query.
     */
     func encode(_ dict: [AnyHashable: Any]) -> String {
         return dict.map { "\($0)=\($1)" }.joined(separator: "&")
+    }
+
+
+    /**
+        Overrides the query of a url with the contents of query parameter.
+
+        - parameter url: the source url.
+        - parameter query: the query that is to be put into the url.
+
+        - returns: a new url with a new query.
+    */
+    func swapQuery(of url: URL, with query: String) -> URL? {
+        guard let components = url.components else {
+            return nil
+        }
+
+        components.query = query
+
+        guard let newURL = components.url else {
+            return nil
+        }
+
+        return newURL
     }
 }

--- a/Sources/snatch/Encoding/URLQueryEncoding.swift
+++ b/Sources/snatch/Encoding/URLQueryEncoding.swift
@@ -35,4 +35,17 @@ class URLQueryEncoding {
 
         return newURL
     }
+
+    /**
+        Overrides the query of a url with the parameters dictionary encoded in URLEncoding query.
+
+        - parameter url: the source url.
+        - parameter parameters: dictionary of parameters.
+
+        - returns: a new url with a new query.
+    */
+    func swapQuery(of url: URL, with parameters: [AnyHashable: Any]) -> URL? {
+        let query = encode(parameters)
+        return swapQuery(of: url, with: query)
+    }
 }

--- a/Sources/snatch/Error/Error+Promised.swift
+++ b/Sources/snatch/Error/Error+Promised.swift
@@ -1,0 +1,7 @@
+import Promise
+
+extension SnatchError {
+    var promised: Promise<Result> {
+        return Promise(error: self)
+    }
+}

--- a/Sources/snatch/Methods/Get.swift
+++ b/Sources/snatch/Methods/Get.swift
@@ -16,7 +16,7 @@ extension Snatch {
             - returns: Promise that fulfills with Snatch.Result object.
         */
         subscript(_ url: URL) -> Promise<Result> {
-            guard let father = self.father else {
+            guard let father = father else {
                 return SnatchError.spooks.promised
             }
             return father.request(url)
@@ -55,8 +55,38 @@ extension Snatch {
             return self[ newURL ]
         }
 
+        /**
+            Encodes parameters if present into url and performs a request using them HTTP headers
+
+            - parameter url: url of a remote endpoint, preferably with http/https protocol.
+            - parameter params: parameters that will be URL encoded into the request. They will be encoded specifically right into a query of a URL, not the body of the HTTP request.
+            - parameter headers: headers dictionary to be used in the request.
+
+            - returns: Promise that fulfills with Snatch.Result object.
+        */
         subscript(_ url: URL, _ params: [AnyHashable: Any]?, _ headers: [String: String]) -> Promise<Result> {
-            return SnatchError.spooks.promised
+            guard let father = father else {
+                return SnatchError.spooks.promised
+            }
+
+            let newUrl: URL
+            if let parameters = params {
+                let encoder = URLQueryEncoding()
+
+                guard let urlWithUpdateQuery = encoder.swapQuery(of: url, with: parameters) else {
+                    return SnatchError.spooks.promised
+                }
+
+                newUrl = urlWithUpdateQuery
+            } else {
+                newUrl = url
+            }
+
+            var request = URLRequest(url: newUrl)
+
+            request.allHTTPHeaderFields = headers
+
+            return father.request(request)
         }
     }
 }

--- a/Sources/snatch/Methods/Get.swift
+++ b/Sources/snatch/Methods/Get.swift
@@ -32,7 +32,7 @@ extension Snatch {
         */
         subscript(_ url: URL, _ params: [AnyHashable: Any]) -> Promise<Result> {
             let encoder = URLQueryEncoding()
-            let query = encoder.encode(params)
+            // let query = encoder.encode(params)
 
             // guard let components = url.components else {
             //     return SnatchError.spooks.promised
@@ -44,7 +44,11 @@ extension Snatch {
             //     return SnatchError.spooks.promised
             // }
 
-            guard let newURL = encoder.swapQuery(of: url, with: query) else {
+            // guard let newURL = encoder.swapQuery(of: url, with: query) else {
+            //     return SnatchError.spooks.promised
+            // }
+
+            guard let newURL = encoder.swapQuery(of: url, with: params) else {
                 return SnatchError.spooks.promised
             }
 

--- a/Sources/snatch/Methods/Get.swift
+++ b/Sources/snatch/Methods/Get.swift
@@ -26,7 +26,6 @@ extension Snatch {
             Encodes parameters into the URL, overriding whatever query it was carrying and resolves upon completion of a request.
 
             - parameter url: url of a remote endpoint, preferably with http/https protocol.
-
             - parameter params: parameters that will be URL encoded into the request. They will be encoded specifically right into a query of a URL, not the body of the HTTP request.
 
             - returns: Promise that fulfills with Snatch.Result object.
@@ -35,13 +34,17 @@ extension Snatch {
             let encoder = URLQueryEncoding()
             let query = encoder.encode(params)
 
-            guard let components = url.components else {
-                return SnatchError.spooks.promised
-            }
+            // guard let components = url.components else {
+            //     return SnatchError.spooks.promised
+            // }
 
-            components.query = query
+            // components.query = query
 
-            guard let newURL = components.url else {
+            // guard let newURL = components.url else {
+            //     return SnatchError.spooks.promised
+            // }
+
+            guard let newURL = encoder.swapQuery(of: url, with: query) else {
                 return SnatchError.spooks.promised
             }
 

--- a/Sources/snatch/Methods/Get.swift
+++ b/Sources/snatch/Methods/Get.swift
@@ -9,7 +9,7 @@ extension Snatch {
         weak var father: Snatch?
 
         /**
-            Starts a data task on a shared URLSession, resolves upon completion.
+            Starts a data task on a URLSession, resolves upon completion.
 
             - parameter url: url of a remote endpoint, preferably with http/https protocol. Any URL encoded body that you would like to include with the request, you have to add **manually**.
 
@@ -17,9 +17,35 @@ extension Snatch {
         */
         subscript(_ url: URL) -> Promise<Result> {
             guard let father = self.father else {
-                return Promise(error: SnatchError.spooks)
+                return SnatchError.spooks.promised
             }
             return father.request(url)
+        }
+
+        /*
+            Encodes parameters into the URL, overriding whatever query it was carrying and resolves upon completion of a request.
+
+            - parameter url: url of a remote endpoint, preferably with http/https protocol.
+
+            - parameter params: parameters that will be URL encoded into the request. They will be encoded specifically right into a query of a URL, not the body of the HTTP request.
+
+            - returns: Promise that fulfills with Snatch.Result object.
+        */
+        subscript(_ url: URL, _ params: [AnyHashable: Any]) -> Promise<Result> {
+            let encoder = URLQueryEncoding()
+            let query = encoder.encode(params)
+
+            guard let components = url.components else {
+                return SnatchError.spooks.promised
+            }
+
+            components.query = query
+
+            guard let newURL = components.url else {
+                return SnatchError.spooks.promised
+            }
+
+            return self[ newURL ]
         }
     }
 }

--- a/Sources/snatch/Methods/Get.swift
+++ b/Sources/snatch/Methods/Get.swift
@@ -16,15 +16,10 @@ extension Snatch {
             - returns: Promise that fulfills with Snatch.Result object.
         */
         subscript(_ url: URL) -> Promise<Result> {
-            return Promise {[weak self] fulfill, reject in
-                guard let father = self?.father else {
-                    reject(SnatchError.spooks)
-                    return
-                }
-                let handler = father.commonHandler(fulfill, reject)
-
-                father.task(with: url, handler).resume()
+            guard let father = self.father else {
+                return Promise(error: SnatchError.spooks)
             }
+            return father.request(url)
         }
     }
 }

--- a/Sources/snatch/Methods/Get.swift
+++ b/Sources/snatch/Methods/Get.swift
@@ -54,5 +54,9 @@ extension Snatch {
 
             return self[ newURL ]
         }
+
+        subscript(_ url: URL, _ params: [AnyHashable: Any]?, _ headers: [String: String]) -> Promise<Result> {
+            return SnatchError.spooks.promised
+        }
     }
 }

--- a/Sources/snatch/Util/URL+components.swift
+++ b/Sources/snatch/Util/URL+components.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension URL {
+    var components: NSURLComponents? {
+        return NSURLComponents(url: self, resolvingAgainstBaseURL: false)
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import snatchTests
 
 XCTMain([
-    // testCase(GeneralTests.allTests),
-    // testCase(GetTests.allTests),
+    testCase(GeneralTests.allTests),
+    testCase(GetTests.allTests),
     testCase(URLQueryEncodingTests.allTests),
 ])

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import snatchTests
 
 XCTMain([
-    testCase(GeneralTests.allTests),
-    testCase(GetTests.allTests),
+    // testCase(GeneralTests.allTests),
+    // testCase(GetTests.allTests),
+    testCase(URLQueryEncodingTests.allTests),
 ])

--- a/Tests/snatchTests/EncodingTests/URLQueryEncodingTests.swift
+++ b/Tests/snatchTests/EncodingTests/URLQueryEncodingTests.swift
@@ -11,12 +11,31 @@ class URLQueryEncodingTests: XCTestCase {
         ]
 
         let expectation = "name=Peter&lastname=Jackson"
+        let anotherExpectation = "lastname=Jackson&name=Peter"
 
         let result = encoding.encode(dict)
-        XCTAssert(expectation == result, "Should produce a valid encoding of the dictionary, but got this \(result)")
+        XCTAssert(expectation == result || anotherExpectation == result, "Should produce a valid encoding of the dictionary, but got this \(result)")
+    }
+
+    func testURLEncodingQuerySwap() {
+        let encoding = URLQueryEncoding()
+        
+        let baseUrl = URL(string: "https://apple.com/shitlang?objectivec=yes")!
+
+        let newQuery = "name=Peter&lastname=Jackson"
+
+        let expectation = "https://apple.com/shitlang?name=Peter&lastname=Jackson"
+
+        guard let newUrl = encoding.swapQuery(of: baseUrl, with: newQuery) else {
+            XCTFail("Should've successfully created new url")
+            return
+        }
+
+        XCTAssert(newUrl.absoluteString == expectation, "Should've successfully swapped query for a new one, but instead resulted in \(newUrl.absoluteString)")
     }
 
     static var allTests = [
         ("testURLEncoding", testURLEncoding),
+        ("testURLEncodingQuerySwap", testURLEncodingQuerySwap),
     ]
 }

--- a/Tests/snatchTests/EncodingTests/URLQueryEncodingTests.swift
+++ b/Tests/snatchTests/EncodingTests/URLQueryEncodingTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import snatch
+
+class URLQueryEncodingTests: XCTestCase {
+    func testURLEncoding() {
+        let encoding = URLQueryEncoding()
+
+        let dict = [
+            "name": "Peter",
+            "lastname": "Jackson"
+        ]
+
+        let expectation = "name=Peter&lastname=Jackson"
+
+        let result = encoding.encode(dict)
+        XCTAssert(expectation == result, "Should produce a valid encoding of the dictionary, but got this \(result)")
+    }
+
+    static var allTests = [
+        ("testURLEncoding", testURLEncoding),
+    ]
+}

--- a/Tests/snatchTests/EncodingTests/URLQueryEncodingTests.swift
+++ b/Tests/snatchTests/EncodingTests/URLQueryEncodingTests.swift
@@ -34,6 +34,26 @@ class URLQueryEncodingTests: XCTestCase {
         XCTAssert(newUrl.absoluteString == expectation, "Should've successfully swapped query for a new one, but instead resulted in \(newUrl.absoluteString)")
     }
 
+    func testURLEncodingQuerySwapButWithParametersArray() {
+        let encoding = URLQueryEncoding()
+        
+        let baseUrl = URL(string: "https://apple.com/shitlang?objectivec=yes")!
+
+        let params = [
+            "name": "Peter",
+            "lastname": "Jackson"
+        ]
+
+        let expectation = "https://apple.com/shitlang?name=Peter&lastname=Jackson"
+
+        guard let newUrl = encoding.swapQuery(of: baseUrl, with: params) else {
+            XCTFail("Should've successfully created new url")
+            return
+        }
+
+        XCTAssert(newUrl.absoluteString == expectation, "Should've successfully swapped query for a new one constructed out of the params we given, but instead resulted in \(newUrl.absoluteString)")
+    }
+
     static var allTests = [
         ("testURLEncoding", testURLEncoding),
         ("testURLEncodingQuerySwap", testURLEncodingQuerySwap),

--- a/Tests/snatchTests/GeneralTests.swift
+++ b/Tests/snatchTests/GeneralTests.swift
@@ -19,7 +19,7 @@ class GeneralTests: XCTestCase {
             exp.fulfill()
         }
         .catch { error in
-            XCTFail("Should've not thrown")
+            XCTFail("Should've not thrown \(error)")
             exp.fulfill()
         }
 

--- a/Tests/snatchTests/MethodTests/GetTests.swift
+++ b/Tests/snatchTests/MethodTests/GetTests.swift
@@ -16,7 +16,7 @@ class GetTests: XCTestCase {
             exp.fulfill()
         }
         .catch { error in
-            XCTFail("Should've not thrown")
+            XCTFail("Should've not thrown \(error)")
             exp.fulfill()
         }
 

--- a/Tests/snatchTests/MethodTests/GetTests.swift
+++ b/Tests/snatchTests/MethodTests/GetTests.swift
@@ -23,6 +23,11 @@ class GetTests: XCTestCase {
         waitForExpectations(timeout: 20.0)
     }
 
+    /*
+        There should be a test of a request with URLEncoded parameters, but you know an echo website? cuz I don't
+        so i can't really think of how am I supposed to test it out...
+    */
+
     static var allTests = [
         ("testGetDownload", testGetDownload),
     ]


### PR DESCRIPTION
### Add methods to execute get requests with URL encoded parameters and custom headers.