### PR TITLE
Crash upon attempt to use Post with headers

### DIFF
--- a/Tests/snatchTests/MethodTests/GetTests.swift
+++ b/Tests/snatchTests/MethodTests/GetTests.swift
@@ -48,7 +48,6 @@ class GetTests: XCTestCase {
         ]
 
         Snatch.shared.get[ url, params, customHeaders ].always {
-            XCTAssert(true, "Should be true")
             exp.fulfill()
         }
 

--- a/Tests/snatchTests/MethodTests/GetTests.swift
+++ b/Tests/snatchTests/MethodTests/GetTests.swift
@@ -34,13 +34,40 @@ class GetTests: XCTestCase {
         XCTAssert(req.httpMethod == "GET", "Should be get by default")
     }
 
+    func testHeadersApplication() {
+        let exp = expectation(description: "Should at least try to download")
+
+        guard let url = URL(string: "https://apple.com/") else {
+            XCTFail("Should've created url to a remote source.")
+            return
+        }
+
+        let params = [
+            "id": "3",
+            "people": "sodds"
+        ]
+
+        Snatch.shared.get[ url, params, customHeaders ].always {
+            XCTAssert(true, "Should be true")
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 20.0)
+    }
+
     /*
         There should be a test of a request with URLEncoded parameters, but you know an echo website? cuz I don't
         so i can't really think of how am I supposed to test it out...
     */
 
+    let customHeaders = [
+        "User-agent" : "AMD286 / MS-DOS 5.0 / Chromium 32.15.133242t4",
+        "Content-Type" : "useless garbage"
+    ]
+
     static var allTests = [
         ("testGetDownload", testGetDownload),
         ("testURLRequestCreation", testURLRequestCreation),
+        ("testHeadersApplication", testHeadersApplication),
     ]
 }

--- a/Tests/snatchTests/MethodTests/PostTests.swift
+++ b/Tests/snatchTests/MethodTests/PostTests.swift
@@ -1,6 +1,18 @@
 import XCTest
 @testable import snatch
 
+extension PostTests {
+    internal class CustomPieceOfData: Encodable {
+        let name: String
+        let age: Int
+
+        init(_ name: String, _ age: Int) {
+            self.name = name
+            self.age = age
+        }
+    }
+}
+
 class PostTests: XCTestCase {
     func testPostModuleRequestGeneration() {
         let post = Snatch.Post()
@@ -9,7 +21,6 @@ class PostTests: XCTestCase {
 
         XCTAssert(req.url == arbitraryURL, "The url should be teh saem.")
         XCTAssertNotNil(req.allHTTPHeaderFields, "The headers should be there.")
-        print(req.allHTTPHeaderFields)
         XCTAssert(req.allHTTPHeaderFields! == customHeaders, "Headers should be the same thing.")
     }
     
@@ -17,7 +28,10 @@ class PostTests: XCTestCase {
         let exp = expectation(description: "Should work")
         
         let snatch = Snatch()
-        snatch.post[ arbitraryURL, ["fuck": 3, "faffing": "over 9000"], customHeaders ].then { res in
+
+        let params = CustomPieceOfData("Jackie", 24)
+
+        snatch.post[ arbitraryURL, params, customHeaders ].then { res in
             exp.fulfill()
         }.catch { error in
             XCTFail("\(error)")

--- a/Tests/snatchTests/MethodTests/PostTests.swift
+++ b/Tests/snatchTests/MethodTests/PostTests.swift
@@ -25,18 +25,14 @@ class PostTests: XCTestCase {
     }
     
     func testPostWithHeaders() {
-        let exp = expectation(description: "Should work")
+        let exp = expectation(description: "Should at very least call the method and successfully complete.")
         
         let snatch = Snatch()
 
         let params = CustomPieceOfData("Jackie", 24)
 
-        snatch.post[ arbitraryURL, params, customHeaders ].then { res in
+        snatch.post[ arbitraryURL, params, customHeaders ].always {
             exp.fulfill()
-        }.catch { error in
-            XCTFail("\(error)")
-        }.always {
-            print("done")
         }
         
         waitForExpectations(timeout: 20.0)

--- a/Tests/snatchTests/MethodTests/PostTests.swift
+++ b/Tests/snatchTests/MethodTests/PostTests.swift
@@ -11,6 +11,19 @@ class PostTests: XCTestCase {
         XCTAssertNotNil(req.allHTTPHeaderFields, "The headers should be there.")
         XCTAssert(req.allHTTPHeaderFields! == customHeaders, "Headers should be the same thing.")
     }
+    
+    func testPostWithHeaders() {
+        let exp = expectation(description: "Should work")
+        
+        let snatch = Snatch()
+        snatch.post[ arbitraryURL, ["fuck": 3, "faffing": "over 9000", customHeaders] ].then { res in
+            exp.fulfill()
+        }.catch { error in
+            XCTFail("\(error)")
+        }
+        
+        waitForExpectations(timeout: 20.0)
+    }
 
     let customHeaders = [
         "User-agent" : "AMD286 / MS-DOS 5.0 / Chromium 32.15.133242t4",
@@ -21,5 +34,6 @@ class PostTests: XCTestCase {
 
     static var allTests = [
         ("testPostModuleRequestGeneration", testPostModuleRequestGeneration),
+        ("testPostWithHeaders", testPostWithHeaders),
     ]
 }

--- a/Tests/snatchTests/MethodTests/PostTests.swift
+++ b/Tests/snatchTests/MethodTests/PostTests.swift
@@ -9,17 +9,20 @@ class PostTests: XCTestCase {
 
         XCTAssert(req.url == arbitraryURL, "The url should be teh saem.")
         XCTAssertNotNil(req.allHTTPHeaderFields, "The headers should be there.")
+        print(req.allHTTPHeaderFields)
         XCTAssert(req.allHTTPHeaderFields! == customHeaders, "Headers should be the same thing.")
     }
     
     func testPostWithHeaders() {
-        let exp = expectation(description: "Should work")
+        let exp = //expectation(description: "Should work")
         
         let snatch = Snatch()
-        snatch.post[ arbitraryURL, ["fuck": 3, "faffing": "over 9000", customHeaders] ].then { res in
+        snatch.post[ arbitraryURL, ["fuck": 3, "faffing": "over 9000"], customHeaders ].then { res in
             exp.fulfill()
         }.catch { error in
             XCTFail("\(error)")
+        }.always {
+            print("done")
         }
         
         waitForExpectations(timeout: 20.0)

--- a/Tests/snatchTests/MethodTests/PostTests.swift
+++ b/Tests/snatchTests/MethodTests/PostTests.swift
@@ -14,7 +14,7 @@ class PostTests: XCTestCase {
     }
     
     func testPostWithHeaders() {
-        let exp = //expectation(description: "Should work")
+        let exp = expectation(description: "Should work")
         
         let snatch = Snatch()
         snatch.post[ arbitraryURL, ["fuck": 3, "faffing": "over 9000"], customHeaders ].then { res in


### PR DESCRIPTION
You would've `snatch.post[ url, params, headers ]` and the app would EXC_BAD_ACCESS. Might've been some problem with symbol resolvation, might've been an issue with Swift's dynamic dispatch.

The original decision of having a private "nilable headers" subscript was that you would people to sent stuff in post requests and thus making Parameters optional was unjustified. Now it's gone, and the API is exactly same as one of Get module. There are also one-two new tests that don't even do much.

Resolves #18 .